### PR TITLE
Do not skip patches with long Subject lines

### DIFF
--- a/procmailrc
+++ b/procmailrc
@@ -4,6 +4,6 @@ MAILDIR=$HOME/incoming/
 LOGFILE=$HOME/incoming/.procmaillog
 
 :0
-`formail -xSubject: | sed -e '{ s/Subject: //; s@\[@@g; s@\]@@g; s@[()]@_@g;
-s@[/:]@-@g; s@"@_@g; s@^ \+@@; s@\.\.@.@g; s@ \+@_@g; s@-_@_@g; s@__@_@g;
-s@\.$@@; }'`.mbox
+`formail -xSubject: | tr '\n' ' ' | sed -e '{ s/Subject: //; s@\[@@g; s@\]@@g; s@[()]@_@g;
+s@[/:]@-@g; s@"@_@g; s@^[[:space:]]\+@@; s@\.\.@.@g; s@[[:space:]]\+@_@g; s@-_@_@g; s@__@_@g;
+s@\.$@@; s@_$@@; }'`.mbox


### PR DESCRIPTION
Problem:
patches with long enough `Subject` lines are skipped

Cause:
1. git-format-patch splits long Subject/Cc over several lines:
```
Subject: [PATCH] iov_iter: Fix iov_iter_extract_pages() with zero-sized
 entries
```
2. formail -xSubject: output such Subject as is, i.e. with newline(s)
3. sed removes (some) whitespace from each of those lines, but not newline(s), the result is
```
PATCH_iov_iter_Fix_iov_iter_extract_pages__with_zero-sized
entries.mbox
```
4. procmail ignores the 2nd line, and the patch is written to `PATCH_iov_iter_Fix_iov_iter_extract_pages__with_zero-sized` file This file is ignored by git-apply script (it picks only `*.mbox` files)

Solution:
Remove newline(s) from formail output. While at it replace all whitespace characters (i.e. tab).

Fixes: #2